### PR TITLE
create-item-table

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,3 +60,4 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem 'mysql2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,7 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     msgpack (1.3.1)
+    mysql2 (0.5.2)
     nio4r (2.5.1)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
@@ -198,6 +199,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
+  mysql2
   puma (~> 3.11)
   rails (~> 5.2.3)
   sass-rails (~> 5.0)

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@
 ## itemsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
+|user_id|references|null: false, foreign_key: true|
 |comment|text|null: false|
-|condition|text|null: false|
+|condition|string|null: false|
 |price|integer|null: false|
 ### Association
 - belongs_to :user

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,0 +1,2 @@
+class Item < ApplicationRecord
+end

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,21 +5,24 @@
 #   gem 'sqlite3'
 #
 default: &default
-  adapter: sqlite3
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  timeout: 5000
+  adapter: mysql2
+  encoding: utf8
+  pool: 5
+  username: root
+  password:
+  socket: /tmp/mysql.sock
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: freemarket_sample_58b_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: freemarket_sample_58b_test
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: freemarket_sample_58b_production

--- a/db/migrate/20190907093000_create_items.rb
+++ b/db/migrate/20190907093000_create_items.rb
@@ -1,0 +1,11 @@
+class CreateItems < ActiveRecord::Migration[5.2]
+  def change
+    create_table :items do |t|
+      # t.references :user_id ,null:false, foreign_key:true
+      t.text :comment, null:false
+      t.string :condition, null:false
+      t.integer :price, null:false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,23 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2019_09_07_093000) do
+
+  create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.text "comment", null: false
+    t.string "condition", null: false
+    t.integer "price", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/test/fixtures/items.yml
+++ b/test/fixtures/items.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ItemTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
#What
Mysqlの導入(Sqliteが導入されていた為)でSequel proでDBを表示させた、itemテーブル作成
※user-idカラムはコメントアウト済み(外部キーの為)

#1 編集したファイル
- gemfile
- datebase.yml
- README.md

#1 作成ファイル
- itemテーブル
- item.rb(モデル)

#Why
デプロイ作業を先にする為
