### PR TITLE
edit README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# README
+# DB設計
 
 ## usersテーブル
 |Column|Type|Options|
@@ -6,7 +6,21 @@
 |nickname|string|null:false|
 |e_mail|string|null:false|
 |password|string|null:false|
-|phone_number|integer|null:false|
+### Association
+- has_many :comments
+- has_many :items
+- has_many :transaction_partners
+- has_one :sns_credentials dependent: :destroy
+- has_one :credit_card dependent: :destroy
+- has_one :profile
+- has_one :address dependent: :destroy
+
+
+## profilesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|introduction|text|null:false|
+|avatar|string|null:false|
 |first_name_kana|string|null:false|
 |last_name_kana|string|null:false|
 |first_name_kanji|string|null:false|
@@ -14,25 +28,63 @@
 |birth_year|integer|null: false|
 |birth_month|integer|null: false|
 |birth_day|integer|null: false|
-
+|user|references|null:false, foreign_key: true|
 ### Association
-- has_many :items
-- has_many :comments
-- has_one :address dependent: :destroy
-- has_one :credit_card dependent: :destroy
-- has_one :sns_credentials dependent: :destroy
+- belongs_to :user
 
 
-## addressesテーブル
+## user_addressesテーブル
 |Column|Type|Options|
 |------|----|-------|
-|user_id|references|null:false, foreign_key: true|
+|user|references|null:false, foreign_key: true|
+|phone_number|integer|null:false, unique:true|
 |postal_code|integer|null:false|
-|prefecture|integer|null:false|
+|prefecture|references|null:false, foreign_key: true|
 |city|string|null:false|
 |block_number|integer||
 |building_name|string||
+### Association
+- belongs_to :user
+- belongs_to_active_hash :prefecture
 
+
+## shipping_addressテーブル
+|Column|Type|Options|
+|------|----|-------|
+|first_name_kana|string|null:false|
+|last_name_kana|string|null:false|
+|first_name_kanji|string|null:false|
+|last_name_kanji|string|null:false|
+|postal_code|integer|null:false|
+|prefecture|references|null:false, foreign_key: true|
+|city|string|null:false|
+|block_number|integer||
+|building_name|string||
+|phone_number|integer|null:false, unique:true|
+|user|references|null:false, foreign_key: true|
+### Association
+- belongs_to :user
+- belongs_to_active_hash :prefecture
+
+
+## credit_cardsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|user|references|null:false,foreign_key:true|
+|card_number|integer|null:false|
+|security_code|integer|null:false|
+|expiry_year|integer|null:false|
+|expiry_month|integer|null:false|
+### Association
+- belongs_to :user
+
+
+## sns_credentialsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|user|references|null:false,foreign_key:true|
+|uid|integer|null:false,unique: true|
+|provider|integer|null:false|
 ### Association
 - belongs_to :user
 
@@ -40,35 +92,32 @@
 ## itemsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|user_id|references|null:false, foreign_key: true|
-|condition|integer|null:false|
-|price|integer|null: false|
 |name|string|null: false|
+|price|integer|null: false|
 |detail|text|null: false|
-|category|integer|null: false|
 |shipping_cost|integer|null: false|
 |shipping_fee_charge_to|integer|null: false|
 |shipping_from|integer|null: false|
-|shipping-days|integer|null: false|
-|seller_id|references|null: false|
-|buyer_id|references|null: false|
-
+|shipping_days|integer|null: false|
+|condition|references|null:false,foreign_key: true|
+|category|references|null:false,foreign_key:true|
+|trade_status|references|null:false,foreign_key:true|
+|brand|references|foreign_key: true|
 ### Association
 - has_many :images dependent: :destory
 - has_many :comments dependent: :destory
-- belongs_to :user
+- has_one :transaction
+- belongs_to_active_hash :condition
 - belongs_to :category
 - belongs_to :brand
-- belongs_to :seller, class_name: "User"
-- belongs_to :buyer, class_name: "User"
+- belongs_to_active_hash :trade_status
 
 
 ## imagesテーブル
 |Column|Type|Options|
 |------|----|-------|
-|item_id|references|null:false,foreign_key:true|
+|item|references|null:false,foreign_key:true|
 |image|string|null: false|
-
 ### Association
 - belongs_to :item
 
@@ -76,11 +125,10 @@
 ## commentsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|user_id|references|null:false, foreign_key: true|
-|item_id|references|null:false, foreign_key: true|
+|user|references|null:false, foreign_key: true|
+|item|references|null:false, foreign_key: true|
 |content|text|null: false|
 |created_at|timestamps|null: false|
-
 ### Association
 - belongs_to :item
 - belongs_to :user
@@ -91,8 +139,8 @@
 |------|----|-------|
 |name|string|null: false|
 |ancestory|string||
-
 ### Association
+- has_many :brands, through: :categories_brands
 - has_many :items
 - has_ancestory
 
@@ -101,30 +149,39 @@
 |Column|Type|Options|
 |------|----|-------|
 |name|string|null: false|
-
 ### Association
 - has_many :items
+- has_many :categories, through: :categories_brands
 
 
-## credit_cardsテーブル
+## categories_brands
 |Column|Type|Options|
 |------|----|-------|
-|user_id|references|null:false,foreign_key:true|
-|card_number|integer|null:false|
-|security_code|integer|null:false|
-|expiry_year|integer|null:false|
-|expiry_month|integer|null:false|
-
+|category|references|null:false, foreign_key: true|
+|brand|references|null:false, foreign_key: true|
 ### Association
-- belongs_to :user
+- belongs_to :category
+- belongs_to :brand
 
 
-## sns_credentialsテーブル
+## transaction_partnersテーブル
 |Column|Type|Options|
 |------|----|-------|
-|user_id|references|null:false,foreign_key:true|
-|uid|integer|null:false,unique: true|
-|provider|integer|null:false|
-
+|buyer|references|null: false, foreign_key: true|
+|seller|references|null: false, foreign_key: true|
 ### Association
-- belongs_to :user
+- belongs_to :buyer, class_name: 'User', foreign_key: 'buyer_id'
+- belongs_to :seller, class_name: 'User', foreign_key: 'seller_id'
+- has_many :transactions
+
+
+## transactionsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|status|references|null:false, foreign_key: true|
+|item|references|null:false, foreign_key: true|
+|transaction_partner|references|null: false, foreign_key: true|
+### Association
+- belongs_to_active_hash :status
+- belongs_to :item
+- belongs_to :transaction_partner


### PR DESCRIPTION
#What
README.mdの編集。
Usersの商品の郵送等に使わない部分の個人情報に関して、操作性の向上のためにprofilesテーブルを作成し、avatarカラムを作成しユーザーの写真をアップロードできるようにした。
商品の郵送に使う情報なので、addressesテーブルに電話番号を追加した。
active_hashを使用し、prefecture, condition, trade_status, statusに関して、静的なデータに関してテーブルを新たに作成することなく、データを参照できるようにした。
User_addressではないところへも送れるようにするため、shipping_addressesテーブルを追加。
各itemの販売状況の把握の為、itemsテーブルにtrade-statusカラムを追加、さらに取引に入ったときの為にtransactionをhas_oneでアソシエーションを組んだ。
Categoriesテーブルとbrandsテーブルは多対多の関係にあるため、中間テーブルcategories_brandsテーブルを作成し、アソシエーションを組んだ。
Transaction_partnersテーブルを作成し、transactionに関わるユーザーのデータを登録できるようにした。
Transactionsテーブルを作成し取引の状況を登録するstatusカラム、アイテムのレコード、取引に関わるtransaction_partnerの情報を外部キーにて参照できるようにした。

＃Why
先日スプリントレビューにて鈴木さんに指摘された点を直しました。itemsテーブルにseller_idとbuyer_id, user_idが存在した点、商品が今売れているのか販売中なのかに関して把握できない点を修正しました。お忙しいとは思いますが、レビューのほどよろしくお願い致します。