### PR TITLE
出品の条件訂正、出品したアイテムのID=ユーザーIDに変更

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -10,10 +10,10 @@ class ItemsController < ApplicationController
   
   def new
     if user_signed_in?
-      redirect_to new_user_session_path
-    else
       @item = Item.new
       @item.images.build
+    else
+      redirect_to new_user_session_path
     end
   end
   def create
@@ -66,7 +66,7 @@ class ItemsController < ApplicationController
       :brand_id,
       :prefecture_id,
       images_attributes: [:image, :item_id]
-    ).merge(user_id: 1)
+    ).merge(user_id: current_user.id)
   end
 
   def set_item

--- a/app/views/shared/_button.html.haml
+++ b/app/views/shared/_button.html.haml
@@ -2,4 +2,3 @@
   .sell-btn__link
     .sell-btn__link__font 出品
     = fa_icon "camera 4x", class: "sell-btn__link__camera"
-


### PR DESCRIPTION
# What
①商品出品ページに移動する条件が逆になっていた
(ユーザーがサインインしているとルートに戻される)ので、
正しい条件にもどしておきました。

②出品したアイテムのIDは、出品したユーザーのIDで登録される様にしました。

# Why
実際に動かす様の変更です。