### PR TITLE
登録画面にパスワード条件追記

### DIFF
--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -70,10 +70,10 @@ class SignupController < ApplicationController
       if session[:provider].present? && session[:uid].present?
         password = Devise.friendly_token.first(7)
         @user = User.create(
-          nickname:session[:nickname], 
-          email: session[:email], 
-          password: "password", 
-          password_confirmation: "password", 
+          nickname:session[:nickname],
+          email: session[:email],
+          password: "password",
+          password_confirmation: "password",
           phone_number: session[:phone_number],
           last_name_kanji: session[:last_name_kanji],
           first_name_kanji: session[:first_name_kanji],

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -13,9 +13,9 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     @omniauth = request.env['omniauth.auth']
     info = User.find_oauth(@omniauth)
     @user = info[:user]
-    if @user.persisted? 
+    if @user.persisted?
       sign_in_and_redirect @user
-    else 
+    else
       @sns = info[:sns]
       session[:provider] = @sns[:provider]
       session[:uid] = @sns[:uid]

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,5 +1,5 @@
 .login-wrapper
-  = render 'shared/signup-header'  
+  = render 'shared/signup-header'
   .login-main
     .login-main__box
       .login-main__box__new
@@ -26,4 +26,4 @@
           = link_to "" do
             %small
               パスワードをお忘れの方
-  = render 'shared/signup-footer'  
+  = render 'shared/signup-footer'

--- a/app/views/signup/registration.html.haml
+++ b/app/views/signup/registration.html.haml
@@ -27,6 +27,7 @@
           
       .registration-main__box__form-area
         = form_for @user, url:  sms_confirmation_signup_index_path, method: :get do |f|
+        
           .registration-main__box__form-area__content
             .registration-main__box__form-area__content__group
               = f.label :nickname, 'ニックネーム'
@@ -43,6 +44,8 @@
               = f.label :password, 'パスワード'
               %span
                 必須
+              %p.text-right
+              英数含めた７文字以上で設定してください。
               = f.password_field :password, autocomplete: "new-password", placeholder: "7文字以上"
             .registration-main__box__form-area__content__group
               = f.label :password_confimation, 'パスワード(確認)'
@@ -80,7 +83,7 @@
               .birthday-select
                 != sprintf(f.date_select(:birthday, start_year: Time.now.year, end_year: Time.now.year - 119, prompt: "--", use_month_numbers: true, date_separator:'%s'),'年 ','月 ')+'日'
               %p.form-info-text
-                ※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。              
+                ※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。
             .registration-main__box__form-area__content__group
               %p
                 「次へ進む」のボタンを押すことにより、利用規約に同意したものとみなします


### PR DESCRIPTION
ユーザー情報を登録する際、パスワードの条件をわかりやすくするため、必須条件を表示するようにした